### PR TITLE
Fix order of calls in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ $ npm i --save newspeak
  */
 
 var newspeak = require('newspeak');
-l20n.currentLanguage('nl');
 var l20n = newspeak({language: 'nl', gender: 'male'});
+l20n.currentLanguage('nl');
 
 /**
  * Create a language object.


### PR DESCRIPTION
Just noticed that these two lines were out of order, apparently.
